### PR TITLE
fix: fetch more pages until next_uri is None

### DIFF
--- a/databend_py/client.py
+++ b/databend_py/client.py
@@ -30,14 +30,10 @@ class Client(object):
         self.connection.disconnect()
 
     def data_generator(self, raw_data):
-
         while raw_data['next_uri'] is not None:
             try:
                 raw_data = self.receive_data(raw_data['next_uri'])
-                if not raw_data['data']:
-                    break
                 yield raw_data
-
             except (Exception, KeyboardInterrupt):
                 self.disconnect()
                 raise

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -43,6 +43,7 @@ class DatabendPyTestCase(TestCase):
         _, r = c.execute("select 1", with_column_types=False)
         self.assertEqual(r, ([(1,)]))
         column_types, _ = c.execute(select_test, with_column_types=True)
+        print(column_types)
         self.assertEqual(column_types, [('db', 'NULL'), ('name', 'String'), ('schema', 'String'), ('type', 'String')])
 
         # test with_column_types=True

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -82,7 +82,7 @@ class DatabendPyTestCase(TestCase):
 
 if __name__ == '__main__':
     print("start test......")
-    os.environ['TEST_DATABEND_DSN'] = "http://root:@localhost:8002"
+    # os.environ['TEST_DATABEND_DSN'] = "http://root:@localhost:8002"
     dt = DatabendPyTestCase(databend_url=os.getenv("TEST_DATABEND_DSN"))
     dt.test_simple()
     dt.test_ordinary_query()


### PR DESCRIPTION
There has a situation: the `data` in the query process may be empty, but the `next_uri` is not empty. So we fetch pages until the `next_url` is None.