### PR TITLE
fix: do not split the data payload into chunks

### DIFF
--- a/databend_py/__init__.py
+++ b/databend_py/__init__.py
@@ -2,7 +2,7 @@ from .client import Client
 from .connection import Connection
 from .datetypes import DatabendDataType
 
-VERSION = (0, 3, 9)
+VERSION = (0, 4, 1)
 __version__ = '.'.join(str(x) for x in VERSION)
 
 __all__ = ['Client', 'Connection', 'DatabendDataType']

--- a/databend_py/client.py
+++ b/databend_py/client.py
@@ -127,11 +127,11 @@ class Client(object):
 
         batch_size = query.count(',') + 1
         if params is not None:
-            tuple_ls = [tuple(params[i:i + batch_size]) for i in range(0, len(params), batch_size)]
-            filename = self.generate_csv(tuple_ls)
+            # tuple_ls = [tuple(params[i:i + batch_size]) for i in range(0, len(params), batch_size)]
+            filename = self.generate_csv(params)
             csv_data = self.get_csv_data(filename)
             self.sync_csv_file_into_table(filename, csv_data, table_name)
-            insert_rows = len(tuple_ls)
+            insert_rows = len(params)
 
         return insert_rows
 

--- a/databend_py/connection.py
+++ b/databend_py/connection.py
@@ -122,7 +122,7 @@ class Connection(object):
                                  verify=True)
         try:
             resp_dict = json.loads(response.content)
-            self.client_session = resp_dict["session"]
+            # self.client_session = resp_dict["session"]
             return resp_dict
         except Exception as err:
             log.logger.error(

--- a/databend_py/connection.py
+++ b/databend_py/connection.py
@@ -122,6 +122,7 @@ class Connection(object):
                                  verify=True)
         try:
             resp_dict = json.loads(response.content)
+            # TODO(liyazhou): got KeyError here
             # self.client_session = resp_dict["session"]
             return resp_dict
         except Exception as err:


### PR DESCRIPTION
the values payload is considered as in the format of `[(1, 2), (1, 2)]` which can be serialized into csv format without splitting batches.

related: https://github.com/databendcloud/databend-cloud-platform/issues/7219