### PR TITLE
refactor: collect the data upload logics into DataUploader

### DIFF
--- a/databend_py/client.py
+++ b/databend_py/client.py
@@ -1,10 +1,5 @@
-import csv
 import json
-import os
 import re
-import requests
-import time
-import uuid
 from urllib.parse import urlparse, parse_qs, unquote
 
 from .connection import Connection

--- a/databend_py/client.py
+++ b/databend_py/client.py
@@ -8,6 +8,7 @@ import uuid
 from urllib.parse import urlparse, parse_qs, unquote
 
 from .connection import Connection
+from .uploader import DataUploader
 from .result import QueryResult
 from .util.escape import escape_params
 from .util.helper import asbool, Helper
@@ -25,6 +26,7 @@ class Client(object):
         self.query_result_cls = QueryResult
         self.helper = Helper
         self._debug = asbool(self.settings.get('debug', False))
+        self._uploader = DataUploader(self, self.settings, debug=self._debug)
 
     def __enter__(self):
         return self
@@ -134,12 +136,8 @@ class Client(object):
         batch_size = query.count(',') + 1
         if params is not None:
             tuple_ls = [tuple(params[i:i + batch_size]) for i in range(0, len(params), batch_size)]
-            filename = self._generate_csv(tuple_ls)
-            with open(filename, "rb") as f:
-                self._sync_csv_file_into_table(f, filename, table_name, "CSV")
             insert_rows = len(tuple_ls)
-            os.remove(filename)
-
+            self._uploader.upload_to_table(table_name, tuple_ls)
         return insert_rows
 
     def _process_ordinary_query(self, query, params=None, with_column_types=False,
@@ -234,14 +232,6 @@ class Client(object):
 
         return cls(host, **kwargs)
 
-    def _generate_csv(self, bindings):
-        file_name = f'/tmp/{uuid.uuid4()}.csv'
-        with open(file_name, "w+") as csvfile:
-            spamwriter = csv.writer(csvfile, delimiter=',', quoting=csv.QUOTE_MINIMAL)
-            spamwriter.writerows(bindings)
-
-        return file_name
-
     def stage_csv_file(self, file_descriptor, file_name):
         stage_path = "@~/%s" % file_name
         start_presign_time = time.time()
@@ -259,17 +249,6 @@ class Client(object):
             if self._debug:
                 print("upload: put file:%s duration:%ss" % (file_name, time.time() - start_upload_time))
         return stage_path
-
-    def _sync_csv_file_into_table(self, file_descriptor, file_name, table, file_type):
-        start = time.time()
-        stage_path = self.stage_csv_file(file_descriptor, file_name)
-        copy_options = self._generate_copy_options()
-        _, _ = self.execute(
-            f"COPY INTO {table} FROM {stage_path} FILE_FORMAT = (type = {file_type} RECORD_DELIMITER = '\r\n')\
-             PURGE = {copy_options['PURGE']} FORCE = {copy_options['FORCE']}\
-              SIZE_LIMIT={copy_options['SIZE_LIMIT']} ON_ERROR = {copy_options['ON_ERROR']}")
-        if self._debug:
-            print("upload: copy %s duration:%ss" % (file_name, int(time.time() - start)))
 
     def upload(self, file_descriptor, file_name, table_name, file_type=None):
         """
@@ -304,27 +283,3 @@ class Client(object):
         resp = requests.put(presigned_url, headers=headers, data=file_descriptor)
         resp.raise_for_status()
         return stage_path
-
-    def _generate_copy_options(self):
-        # copy options docs: https://databend.rs/doc/sql-commands/dml/dml-copy-into-table#copyoptions
-        copy_options = {}
-        if "copy_purge" in self.settings:
-            copy_options["PURGE"] = self.settings["copy_purge"]
-        else:
-            copy_options["PURGE"] = False
-
-        if "force" in self.settings:
-            copy_options["FORCE"] = self.settings["force"]
-        else:
-            copy_options["FORCE"] = False
-
-        if "size_limit" in self.settings:
-            copy_options["SIZE_LIMIT"] = self.settings["size_limit"]
-        else:
-            copy_options["SIZE_LIMIT"] = 0
-        if "on_error" in self.settings:
-            copy_options["ON_ERROR"] = self.settings["on_error"]
-
-        else:
-            copy_options["ON_ERROR"] = "abort"
-        return copy_options

--- a/databend_py/client.py
+++ b/databend_py/client.py
@@ -234,6 +234,7 @@ class Client(object):
         table_name: the table which write into
         data: the data which write into, it's a list of tuple
         """
+        # TODO: escape the database & table name
         self._uploader.upload_to_table("%s.%s" % (database_name, table_name), data)
 
     def upload_to_stage(self, stage_dir, file_name, data):

--- a/databend_py/client.py
+++ b/databend_py/client.py
@@ -227,13 +227,14 @@ class Client(object):
 
         return cls(host, **kwargs)
 
-    def upload(self, table_name, data):
+    def insert(self, database_name, table_name, data):
         """
-        upload the file to database.table according to the file
+        insert the data into database.table according to the file
+        database_name: the target database
         table_name: the table which write into
         data: the data which write into, it's a list of tuple
         """
-        self._uploader.upload_to_table(table_name, data)
+        self._uploader.upload_to_table("%s.%s" % (database_name, table_name), data)
 
     def upload_to_stage(self, stage_dir, file_name, data):
         """

--- a/databend_py/connection.py
+++ b/databend_py/connection.py
@@ -9,16 +9,10 @@ import requests
 from . import log
 from . import defines
 from .context import Context
-from databend_py.errors import WarehouseTimeoutException, UnexpectedException
+from databend_py.errors import WarehouseTimeoutException, UnexpectedException, ServerException
 from databend_py.retry import retry
 
 headers = {'Content-Type': 'application/json', 'Accept': 'application/json', 'X-DATABEND-ROUTE': 'warehouse'}
-
-
-class Error:
-    def __init__(self, msg, errno):
-        self.msg = msg
-        self.errno = errno
 
 
 class ServerInfo(object):
@@ -58,8 +52,9 @@ def get_error(response):
         return None
 
     # Wrap errno into msg, for result check
-    return Error(msg=response['error']['message'],
-                 errno=response['error']['code'])
+    return ServerError(
+        response['error']['message'],
+        response['error']['code'])
 
 
 class Connection(object):

--- a/databend_py/connection.py
+++ b/databend_py/connection.py
@@ -52,7 +52,7 @@ def get_error(response):
         return None
 
     # Wrap errno into msg, for result check
-    return ServerError(
+    return ServerException(
         response['error']['message'],
         response['error']['code'])
 

--- a/databend_py/connection.py
+++ b/databend_py/connection.py
@@ -82,6 +82,7 @@ class Connection(object):
         self.additional_headers = dict()
         self.query_option = None
         self.context = Context()
+        self.requests_session = requests.Session()
         self.schema = 'http'
         if self.secure:
             self.schema = 'https'
@@ -112,7 +113,7 @@ class Connection(object):
 
     @retry(times=5, exceptions=WarehouseTimeoutException)
     def do_query(self, url, query_sql):
-        response = requests.post(url,
+        response = self.requests_session.post(url,
                                  data=json.dumps(query_sql),
                                  headers=self.make_headers(),
                                  auth=HTTPBasicAuth(self.user, self.password),
@@ -159,7 +160,7 @@ class Connection(object):
 
     def next_page(self, next_uri):
         url = "{}://{}:{}{}".format(self.schema, self.host, self.port, next_uri)
-        return requests.get(url=url, headers=self.make_headers())
+        return self.requests_session.get(url=url, headers=self.make_headers())
 
     # return a list of response util empty next_uri
     def query_with_session(self, statement):

--- a/databend_py/connection.py
+++ b/databend_py/connection.py
@@ -6,7 +6,6 @@ from requests.auth import HTTPBasicAuth
 
 import environs
 import requests
-from mysql.connector.errors import Error
 from . import log
 from . import defines
 from .context import Context
@@ -14,6 +13,12 @@ from databend_py.errors import WarehouseTimeoutException
 from databend_py.retry import retry
 
 headers = {'Content-Type': 'application/json', 'Accept': 'application/json', 'X-DATABEND-ROUTE': 'warehouse'}
+
+
+class Error:
+    def __init__(self, msg, errno):
+        self.msg = msg
+        self.errno = errno
 
 
 class ServerInfo(object):

--- a/databend_py/errors.py
+++ b/databend_py/errors.py
@@ -30,7 +30,7 @@ class WarehouseTimeoutException(Error):
         return 'Provision warehouse timeout: {}'.format(self.message)
 
 
-class UnexpectedException(Error)
+class UnexpectedException(Error):
     def __init__(self, message):
         self.message = message
         super(UnexpectedException, self).__init__(message)

--- a/databend_py/errors.py
+++ b/databend_py/errors.py
@@ -17,7 +17,7 @@ class ServerException(Error):
         super(ServerException, self).__init__(message)
 
     def __str__(self):
-        return 'Code: {}\n{}'.format(self.code, self.message)
+        return 'Code: {} {}'.format(self.code, self.message)
 
 
 class WarehouseTimeoutException(Error):
@@ -27,4 +27,14 @@ class WarehouseTimeoutException(Error):
         super(WarehouseTimeoutException, self).__init__(message)
 
     def __str__(self):
-        return 'Provision warehouse timeout: \n{}'.format(self.message)
+        return 'Provision warehouse timeout: {}'.format(self.message)
+
+
+class UnexpectedException(Error)
+    def __init__(self, message):
+        self.message = message
+        super(UnexpectedException, self).__init__(message)
+
+    def __str__(self):
+        message = ' ' + self.message if self.message is not None else ''
+        return 'Unexpected: {}'.format(message)

--- a/databend_py/uploader.py
+++ b/databend_py/uploader.py
@@ -3,29 +3,32 @@ import io
 
 
 class DataUploader:
-    def __init__(self, client, settings, stage_dir='@~', debug=False):
+    def __init__(self, client, settings, default_stage_dir='@~', debug=False):
         # TODO: make it depends on Connection instead of Client
         self.client = client
         self.debug = debug
         self.settings = settings
-        self.stage_dir = stage_dir
+        self.default_stage_dir = default_stage_dir
 
-    def upload_to_table(self, database, table, data):
-        stage_path = self._gen_stage_path()
+    def upload_to_table(self, table_name, data):
+        stage_path = self._gen_stage_path(self.default_stage_dir)
         presigned_url, headers = self._execute_presign(stage_path)
         self._upload_to_presigned_url(presigned_url, headers, data)
-        self._execute_copy(database, table, stage_path)
+        self._execute_copy(table_name, stage_path)
 
-    def upload_to_stage(self, filename, data):
-        pass
+    def upload_to_stage(self, stage_dir, filename, data):
+        stage_path = self._gen_stage_path(stage_dir, filename)
+        presigned_url, headers = self._execute_presign(stage_path)
+        self._upload_to_presigned_url(presigned_url, headers, data)
+        return stage_path
 
-    def _gen_stage_path(self, stage_filename=None):
+    def _gen_stage_path(self, stage_dir, stage_filename=None):
         if stage_filename is None:
             stage_filename = '%s.csv' % uuid.uuid4()
         if stage_filename.startswith('/'):
             stage_filename = stage_filename[1:]
         # TODO: escape the stage_path if it contains special characters
-        stage_path = '%s/%s' % (self.stage_dir, stage_filename)
+        stage_path = '%s/%s' % (stage_dir, stage_filename)
         return stage_path
 
     def _execute_presign(self, stage_path):
@@ -35,19 +38,23 @@ class DataUploader:
         return presigned_url, headers
 
     def _upload_to_presigned_url(self, presigned_url, headers, data):
-        buf = io.BytesIO()
-        w = csv.writer(f, delimiter=',', quoting=csv.QUOTE_MINIMAL)
-        w.writerows(data)
+        # TODO: if data's type is bytes or File, then upload it directly
+        if isinstance(data, list):
+            buf = io.BytesIO()
+            w = csv.writer(f, delimiter=',', quoting=csv.QUOTE_MINIMAL)
+            w.writerows(data)
+        else:
+            raise Exception('data is not a list: %s' % type(data))
         resp = requests.put(presigned_url, headers=headers, data=buf)
         resp.raise_for_status()
 
-    def _execute_copy(self, database, table, stage_path):
-        sql = self._make_copy_statement(database, table, stage_path)
+    def _execute_copy(self, table_name, stage_path):
+        sql = self._make_copy_statement(table_name, stage_path)
         self.client.execute(sql)
 
-    def _make_copy_statement(self, database, table, stage_path):
+    def _make_copy_statement(self, table_name, stage_path):
         copy_options = self._generate_copy_options()
-        return f"COPY INTO {database}.{table} FROM {stage_path} " \
+        return f"COPY INTO {table_name} FROM {stage_path} " \
             f"FILE_FORMAT = (type = {file_type} RECORD_DELIMITER = '\r\n') " \
             f"PURGE = {copy_options['PURGE']} FORCE = {copy_options['FORCE']} " \
             f"SIZE_LIMIT={copy_options['SIZE_LIMIT']} ON_ERROR = {copy_options['ON_ERROR']}"

--- a/databend_py/uploader.py
+++ b/databend_py/uploader.py
@@ -58,7 +58,7 @@ class DataUploader:
             raise Exception('data is not a list: %s' % type(data))
         start_time = time.time()
         try:
-            resp = requests.put(presigned_url, headers=headers, data=buf)
+            resp = requests.put(presigned_url, headers=headers, data=buf.getvalue())
             resp.raise_for_status()
         finally:
             if self._debug:

--- a/databend_py/uploader.py
+++ b/databend_py/uploader.py
@@ -49,6 +49,7 @@ class DataUploader:
         if isinstance(data, list):
             buf = io.BytesIO()
             buf_writer = csv.writer(buf, delimiter=',', quoting=csv.QUOTE_MINIMAL)
+            print(data)
             buf_writer.writerows(data)
             buf_size = buf.getbuffer().nbytes
             data_len = len(data)

--- a/databend_py/uploader.py
+++ b/databend_py/uploader.py
@@ -15,6 +15,8 @@ class DataUploader:
         self._debug = debug
 
     def upload_to_table(self, table_name, data):
+        if len(data) == 0:
+            return
         stage_path = self._gen_stage_path(self.default_stage_dir)
         presigned_url, headers = self._execute_presign(stage_path)
         self._upload_to_presigned_url(presigned_url, headers, data)

--- a/databend_py/uploader.py
+++ b/databend_py/uploader.py
@@ -47,11 +47,11 @@ class DataUploader:
     def _upload_to_presigned_url(self, presigned_url, headers, data):
         # TODO: if data's type is bytes or File, then upload it directly
         if isinstance(data, list):
-            buf = io.BytesIO()
+            buf = io.StringIO()
             buf_writer = csv.writer(buf, delimiter=',', quoting=csv.QUOTE_MINIMAL)
             print(data)
             buf_writer.writerows(data)
-            buf_size = buf.getbuffer().nbytes
+            buf_size = len(buf.getvalue())
             data_len = len(data)
         else:
             raise Exception('data is not a list: %s' % type(data))

--- a/databend_py/uploader.py
+++ b/databend_py/uploader.py
@@ -49,7 +49,6 @@ class DataUploader:
         if isinstance(data, list):
             buf = io.StringIO()
             buf_writer = csv.writer(buf, delimiter=',', quoting=csv.QUOTE_MINIMAL)
-            print(data)
             buf_writer.writerows(data)
             buf_size = len(buf.getvalue())
             data_len = len(data)

--- a/databend_py/uploader.py
+++ b/databend_py/uploader.py
@@ -10,9 +10,9 @@ class DataUploader:
     def __init__(self, client, settings, default_stage_dir='@~', debug=False):
         # TODO: make it depends on Connection instead of Client
         self.client = client
-        self.debug = debug
         self.settings = settings
         self.default_stage_dir = default_stage_dir
+        self._debug = debug
 
     def upload_to_table(self, table_name, data):
         stage_path = self._gen_stage_path(self.default_stage_dir)

--- a/databend_py/uploader.py
+++ b/databend_py/uploader.py
@@ -1,0 +1,77 @@
+import requests
+import io
+
+
+class DataUploader:
+    def __init__(self, client, settings, stage_dir='@~', debug=False):
+        # TODO: make it depends on Connection instead of Client
+        self.client = client
+        self.debug = debug
+        self.settings = settings
+        self.stage_dir = stage_dir
+
+    def upload_to_table(self, database, table, data):
+        stage_path = self._gen_stage_path()
+        presigned_url, headers = self._execute_presign(stage_path)
+        self._upload_to_presigned_url(presigned_url, headers, data)
+        self._execute_copy(database, table, stage_path)
+
+    def upload_to_stage(self, filename, data):
+        pass
+
+    def _gen_stage_path(self, stage_filename=None):
+        if stage_filename is None:
+            stage_filename = '%s.csv' % uuid.uuid4()
+        if stage_filename.startswith('/'):
+            stage_filename = stage_filename[1:]
+        # TODO: escape the stage_path if it contains special characters
+        stage_path = '%s/%s' % (self.stage_dir, stage_filename)
+        return stage_path
+
+    def _execute_presign(self, stage_path):
+        _, row = self.client.execute('presign upload %s' % stage_path)
+        presigned_url = row[0][2]
+        headers = json.loads(row[0][1])
+        return presigned_url, headers
+
+    def _upload_to_presigned_url(self, presigned_url, headers, data):
+        buf = io.BytesIO()
+        w = csv.writer(f, delimiter=',', quoting=csv.QUOTE_MINIMAL)
+        w.writerows(data)
+        resp = requests.put(presigned_url, headers=headers, data=buf)
+        resp.raise_for_status()
+
+    def _execute_copy(self, database, table, stage_path):
+        sql = self._make_copy_statement(database, table, stage_path)
+        self.client.execute(sql)
+
+    def _make_copy_statement(self, database, table, stage_path):
+        copy_options = self._generate_copy_options()
+        return f"COPY INTO {database}.{table} FROM {stage_path} " \
+            f"FILE_FORMAT = (type = {file_type} RECORD_DELIMITER = '\r\n') " \
+            f"PURGE = {copy_options['PURGE']} FORCE = {copy_options['FORCE']} " \
+            f"SIZE_LIMIT={copy_options['SIZE_LIMIT']} ON_ERROR = {copy_options['ON_ERROR']}"
+
+    def _generate_copy_options(self):
+        # copy options docs: https://databend.rs/doc/sql-commands/dml/dml-copy-into-table#copyoptions
+        copy_options = {}
+        if "copy_purge" in self.settings:
+            copy_options["PURGE"] = self.settings["copy_purge"]
+        else:
+            copy_options["PURGE"] = False
+
+        if "force" in self.settings:
+            copy_options["FORCE"] = self.settings["force"]
+        else:
+            copy_options["FORCE"] = False
+
+        if "size_limit" in self.settings:
+            copy_options["SIZE_LIMIT"] = self.settings["size_limit"]
+        else:
+            copy_options["SIZE_LIMIT"] = 0
+
+        if "on_error" in self.settings:
+            copy_options["ON_ERROR"] = self.settings["on_error"]
+        else:
+            copy_options["ON_ERROR"] = "abort"
+        return copy_options

--- a/databend_py/uploader.py
+++ b/databend_py/uploader.py
@@ -47,6 +47,7 @@ class DataUploader:
             buf_writer = csv.writer(buf, delimiter=',', quoting=csv.QUOTE_MINIMAL)
             buf_writer.writerows(data)
             buf_size = buf.getbuffer().nbytes
+            data_len = len(data)
         else:
             raise Exception('data is not a list: %s' % type(data))
         start_time = time.time()
@@ -55,7 +56,7 @@ class DataUploader:
             resp.raise_for_status()
         finally:
             if self._debug:
-                print('upload:_upload_to_presigned_url bufsize=%d %s' % (buf_size, time.time() - start_time))
+                print('upload:_upload_to_presigned_url len=%d bufsize=%d %s' % (data_len, buf_size, time.time() - start_time))
 
     def _execute_copy(self, table_name, stage_path):
         start_time = time.time()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -100,7 +100,7 @@ class DatabendPyTestCase(TestCase):
         client.execute('DROP TABLE IF EXISTS test_upload')
         client.execute('CREATE TABLE if not exists test_upload (x Int32,y VARCHAR)')
         client.execute('DESC test_upload')
-        client.upload("default.test_upload", [(1, 'a'), (1, 'b')])
+        client.insert("default", "test_upload", [(1, 'a'), (1, 'b')])
         _, upload_res = client.execute('select * from test_upload')
         self.assertEqual(upload_res, [(1, 'a'), (1, 'b')])
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -100,7 +100,7 @@ class DatabendPyTestCase(TestCase):
         client.execute('DROP TABLE IF EXISTS test_upload')
         client.execute('CREATE TABLE if not exists test_upload (x Int32,y VARCHAR)')
         client.execute('DESC test_upload')
-        client.upload("default.test_upload", [(1, 'a'), (1, 'b'))])
+        client.upload("default.test_upload", [(1, 'a'), (1, 'b')])
         _, upload_res = client.execute('select * from test_upload')
         self.assertEqual(upload_res, [(1, 'a'), (1, 'b')])
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -81,7 +81,7 @@ class DatabendPyTestCase(TestCase):
         c.execute('DROP TABLE IF EXISTS test')
         c.execute('CREATE TABLE if not exists test (x Int32,y VARCHAR)')
         c.execute('DESC  test')
-        _, r1 = c.execute('INSERT INTO test (x,y) VALUES (%,%)', [(3, 'aa'), (4, 'bb')])
+        _, r1 = c.execute('INSERT INTO test (x,y) VALUES', [(3, 'aa'), (4, 'bb')])
         self.assertEqual(r1, 2)
         _, ss = c.execute('select * from test')
         self.assertEqual(ss, [(3, 'aa'), (4, 'bb')])

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -106,7 +106,7 @@ class DatabendPyTestCase(TestCase):
 
     def test_upload_to_stage(self):
         client = Client.from_url(self.databend_url)
-        stage_path = client.upload_to_stage('@~', "upload.csv", [(1, 'a'), (1, 'b'))]])
+        stage_path = client.upload_to_stage('@~', "upload.csv", [(1, 'a'), (1, 'b')])
         self.assertEqual(stage_path, "@~/upload.csv")
 
     def tearDown(self):


### PR DESCRIPTION
this PR introduced a DataUploader class to collect the logics about data uploadings with the presign mechanism, with a few changes:

- fixed a @~//tmp/xxx-xxx.csv not found error
- make a memory bytes buf instead of a csv file on disk
- do not depend on mysql connector's Error type
- add keep alive